### PR TITLE
Add a target for running automated tests (as testbot does it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ include these tasks as well with the following line in your build.xml:
 <import file="vendor/doghouseagency/phing-drush/build.files.xml" optional="true" />
 <import file="vendor/doghouseagency/phing-drush/build.install.xml" optional="true" />
 <import file="vendor/doghouseagency/phing-drush/build.maintenance.xml" optional="true" />
+<import file="vendor/doghouseagency/phing-drush/build.tests.xml" optional="true" />
 <import file="vendor/doghouseagency/phing-drush/build.user.xml" optional="true" />
 <import file="vendor/doghouseagency/phing-drush/build.watchdog.xml" optional="true" />
 ```

--- a/build.tests.xml
+++ b/build.tests.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project name="drush-tests" default="tests:run">
+
+  <!-- ## Properties -->
+
+  <property name="tests.bin"          value="${project.basedir}/docroot/core/scripts/run-tests.sh" />
+  <property name="tests.localaddress" value="0.0.0.0:8888" />
+  <property name="tests.localurl"     value="http://localhost:8888/" />
+  <property name="tests.docroot"      value="docroot" />
+  <property name="tests.db"           value="/tmp/tests-db.sqlite" />
+  <property name="tests.dburl"        value="sqlite://localhost//tmp/tests-db.sqlite" />
+  <property name="tests.suite"        value="minimal" />
+
+  <!-- ## Targets -->
+
+  <target name="tests:run"
+          description="Runs all the automated tests for this suite.">
+    <!-- Stop the webserver just for running the browser tests -->
+    <exec command="php -S ${tests.localaddress} -t ${tests.docroot}" spawn="true"/>
+    <!-- Run the tests -->
+    <exec command="php ${tests.bin} --php php -- --url ${tests.localurl} --sqlite ${tests.db} --dburl ${tests.dburl} --suppress-deprecations ${tests.suite}"
+          passthru="true"
+          checkreturn="true" />
+    <!-- Cleanup any created test files -->
+    <exec command="php ${tests.bin} --php php -- --sqlite ${tests.db} --clean --dburl ${tests.dburl} --verbose"/>
+    <!-- Stop the webserver for running the tests -->
+    <exec command="pkill -f 'php -S ${tests.localaddress} -t ${tests.docroot}'"/>
+  </target>
+
+</project>


### PR DESCRIPTION
This will:
* start a local testing webserver
* execute the given test suite
* stop the testing webserver
* cleanup and files used for testing

Use it:
> phing tests -Dtests.suite=suite

The default test suite is "minimal".

Supports Unit, Kernel, Functional and FunctionalJavascript tests.
